### PR TITLE
Fix dim mismatch in Up/Down ProjectBlocks, a5

### DIFF
--- a/a5/src/model.py
+++ b/a5/src/model.py
@@ -110,7 +110,7 @@ class DownProjectBlock(nn.Module):
         ### YOUR CODE HERE
         ### Hint: Copy over the code from Block and make necessary modifications.
         ### Should be around 3-5 lines.
-        x = x_input + self.attn(self.ln1(self.C), self.ln1(x_input))
+        x = self.attn(self.ln1(x_input), self.ln1(self.C))
         x = x + self.mlp(self.ln2(x))
         return x
         ### END YOUR CODE
@@ -146,7 +146,7 @@ class UpProjectBlock(nn.Module):
         ### YOUR CODE HERE
         ### Hint: Copy over the code from Block and make necessary modifications.
         ### Should be around 3-5 lines.
-        x = y + self.attn(self.ln1(y), x_input)
+        x = self.attn(self.ln1(y), x_input)
         x = x + self.mlp(self.ln2(x))
         return x
         ### END YOUR CODE


### PR DESCRIPTION
Hey there,

Big thanks for sharing the repo! I stumbled upon a little hiccup in the `DownProjectBlock` and `UpProjectBlock` in a5 and found a dimension mismatch in the residual connections (e.g. the original sequence length of x_input was 128, which does not match the `bottleneck_dim=64` after down projection). I simply removed these connections after CrossAttention and solved the problem.

The original Perceiver [paper](http://arxiv.org/abs/2202.07765) only includes CrossAttention in the first and last layers, so I figured aligning with the original paper might clear things up. I left the layer norm and mlp as-is since they don't seem to mess with the performance.

I hope my little tweak helps. Feel free to reach out if you need more details.

Cheers!